### PR TITLE
 fix bug in DP when domain parallel is on

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -5,6 +5,13 @@
 
 
 --------------
+Aug 27, 2020
+Name: Qimen Xu
+Changes: (eigensolver.c, eigensolverKpt.c)
+1. Bug fix in DP: when DP is turned on and npdomain > 1, eigenvalues are only correct in the first dmcomm.
+
+
+--------------
 Jul 24, 2020
 Name: Qimen Xu, Abhiraj Sharma
 Changes: (eigensolver.c, stress.c)

--- a/ChangeLog
+++ b/ChangeLog
@@ -5,6 +5,14 @@
 
 
 --------------
+Jul 24, 2020
+Name: Qimen Xu, Abhiraj Sharma
+Changes: (eigensolver.c, stress.c)
+1. Removed repetitive part involving finding global max and min of eigenvalues among spin communicators.
+2. Fixed bug related to specification of BCy instead of BCz while calculating cell measure (5 places).
+
+
+--------------
 Jun 22, 2020
 Name: Qimen Xu
 Changes: 

--- a/src/eigenSolver.c
+++ b/src/eigenSolver.c
@@ -204,10 +204,10 @@ void eigSolve_CheFSI(int rank, SPARC_OBJ *pSPARC, int SCFcount, double error) {
             MPI_Allreduce(MPI_IN_PLACE, &eigmax_g, 1, MPI_DOUBLE, MPI_MAX, pSPARC->spin_bridge_comm);
         }
         
-        if (pSPARC->npspin != 1) { // find min/max over processes with the same rank in spincomm
-            MPI_Allreduce(MPI_IN_PLACE, &eigmin_g, 1, MPI_DOUBLE, MPI_MIN, pSPARC->spin_bridge_comm);
-            MPI_Allreduce(MPI_IN_PLACE, &eigmax_g, 1, MPI_DOUBLE, MPI_MAX, pSPARC->spin_bridge_comm);
-        }
+        //if (pSPARC->npspin != 1) { // find min/max over processes with the same rank in spincomm
+        //    MPI_Allreduce(MPI_IN_PLACE, &eigmin_g, 1, MPI_DOUBLE, MPI_MIN, pSPARC->spin_bridge_comm);
+        //    MPI_Allreduce(MPI_IN_PLACE, &eigmax_g, 1, MPI_DOUBLE, MPI_MAX, pSPARC->spin_bridge_comm);
+        //}
         
         pSPARC->Efermi = Calculate_occupation(pSPARC, eigmin_g-1.0, eigmax_g+1.0, 1e-12, 100); 
         

--- a/src/initialization.c
+++ b/src/initialization.c
@@ -2208,7 +2208,7 @@ void write_output_init(SPARC_OBJ *pSPARC) {
     }
 
     fprintf(output_fp,"***************************************************************************\n");
-    fprintf(output_fp,"*                       SPARC (version Jul 24, 2020)                      *\n");  
+    fprintf(output_fp,"*                       SPARC (version Aug 27, 2020)                      *\n");  
     fprintf(output_fp,"*   Copyright (c) 2020 Material Physics & Mechanics Group, Georgia Tech   *\n");
     fprintf(output_fp,"*           Distributed under GNU General Public License 3 (GPL)          *\n");
     fprintf(output_fp,"*                   Start time: %s                  *\n",c_time_str);

--- a/src/initialization.c
+++ b/src/initialization.c
@@ -2208,7 +2208,7 @@ void write_output_init(SPARC_OBJ *pSPARC) {
     }
 
     fprintf(output_fp,"***************************************************************************\n");
-    fprintf(output_fp,"*                       SPARC (version Jun 22, 2020)                      *\n");  
+    fprintf(output_fp,"*                       SPARC (version Jul 24, 2020)                      *\n");  
     fprintf(output_fp,"*   Copyright (c) 2020 Material Physics & Mechanics Group, Georgia Tech   *\n");
     fprintf(output_fp,"*           Distributed under GNU General Public License 3 (GPL)          *\n");
     fprintf(output_fp,"*                   Start time: %s                  *\n",c_time_str);

--- a/src/stress.c
+++ b/src/stress.c
@@ -78,7 +78,7 @@ void Calculate_ionic_stress(SPARC_OBJ *pSPARC){
         cell_measure *= pSPARC->range_x;
     if(pSPARC->BCy == 0)
         cell_measure *= pSPARC->range_y;
-    if(pSPARC->BCy == 0)
+    if(pSPARC->BCz == 0)
         cell_measure *= pSPARC->range_z;
 
     for(j = 0; j < 6; j++){
@@ -250,7 +250,7 @@ void Calculate_XC_stress(SPARC_OBJ *pSPARC) {
             cell_measure *= pSPARC->range_x;
         if(pSPARC->BCy == 0)
             cell_measure *= pSPARC->range_y;
-        if(pSPARC->BCy == 0)
+        if(pSPARC->BCz == 0)
             cell_measure *= pSPARC->range_z;
 
        for(int i = 0; i < 6; i++)
@@ -678,7 +678,7 @@ void Calculate_local_stress(SPARC_OBJ *pSPARC) {
             cell_measure *= pSPARC->range_x;
         if(pSPARC->BCy == 0)
             cell_measure *= pSPARC->range_y;
-        if(pSPARC->BCy == 0)
+        if(pSPARC->BCz == 0)
             cell_measure *= pSPARC->range_z;
 
        for(int i = 0; i < 6; i++)
@@ -1055,7 +1055,7 @@ void Calculate_nonlocal_kinetic_stress(SPARC_OBJ *pSPARC)
             cell_measure *= pSPARC->range_x;
         if(pSPARC->BCy == 0)
             cell_measure *= pSPARC->range_y;
-        if(pSPARC->BCy == 0)
+        if(pSPARC->BCz == 0)
             cell_measure *= pSPARC->range_z;
 
        for(int i = 0; i < 6; i++) {
@@ -1473,7 +1473,7 @@ void Calculate_nonlocal_kinetic_stress_kpt(SPARC_OBJ *pSPARC)
             cell_measure *= pSPARC->range_x;
         if(pSPARC->BCy == 0)
             cell_measure *= pSPARC->range_y;
-        if(pSPARC->BCy == 0)
+        if(pSPARC->BCz == 0)
             cell_measure *= pSPARC->range_z;
 
        for(int i = 0; i < 6; i++) {


### PR DESCRIPTION
Bugfix in DP: when DP is turned on and npdomain > 1, eigenvalues are only correct in the first dmcomm.