### PR TITLE
add option to enable SIMD for complex stencil routines

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -5,6 +5,13 @@
 
 
 --------------
+Oct 18, 2020
+Name: Qimen Xu
+Changes: (*Kpt.c)
+1. Add compiling option to enable SIMD vectorization of complex stencil routines (use when intel/19.0.3 or later versions of compilers are available).
+
+
+--------------
 Oct 01, 2020
 Name: Qimen Xu
 Changes: (readfiles.c)

--- a/ChangeLog
+++ b/ChangeLog
@@ -5,7 +5,7 @@
 
 
 --------------
-Sep 30, 2020
+Oct 01, 2020
 Name: Qimen Xu
 Changes: (readfiles.c)
 1. Modify the function for reading pseudopotentials to support two formats of converted TM pseudopotentials.

--- a/src/gradVecRoutinesKpt.c
+++ b/src/gradVecRoutinesKpt.c
@@ -438,7 +438,9 @@ void Calc_DX_kpt(
             int jshift_DX = kshift_DX + j * stride_y_DX;
             int jshift_X = kshift_X + jj * stride_y_X;
             const int niters = x_DX_epos - x_DX_spos;
-            #pragma omp simd
+#ifdef ENABLE_SIMD_COMPLEX            
+#pragma omp simd
+#endif            
             for (i = 0; i < niters; i++)
             {
                 int ishift_DX = jshift_DX + i + x_DX_spos;

--- a/src/initialization.c
+++ b/src/initialization.c
@@ -2208,7 +2208,7 @@ void write_output_init(SPARC_OBJ *pSPARC) {
     }
 
     fprintf(output_fp,"***************************************************************************\n");
-    fprintf(output_fp,"*                       SPARC (version Sep 30, 2020)                      *\n");  
+    fprintf(output_fp,"*                       SPARC (version Oct 01, 2020)                      *\n");  
     fprintf(output_fp,"*   Copyright (c) 2020 Material Physics & Mechanics Group, Georgia Tech   *\n");
     fprintf(output_fp,"*           Distributed under GNU General Public License 3 (GPL)          *\n");
     fprintf(output_fp,"*                   Start time: %s                  *\n",c_time_str);

--- a/src/initialization.c
+++ b/src/initialization.c
@@ -2208,7 +2208,7 @@ void write_output_init(SPARC_OBJ *pSPARC) {
     }
 
     fprintf(output_fp,"***************************************************************************\n");
-    fprintf(output_fp,"*                       SPARC (version Oct 01, 2020)                      *\n");  
+    fprintf(output_fp,"*                       SPARC (version Oct 18, 2020)                      *\n");  
     fprintf(output_fp,"*   Copyright (c) 2020 Material Physics & Mechanics Group, Georgia Tech   *\n");
     fprintf(output_fp,"*           Distributed under GNU General Public License 3 (GPL)          *\n");
     fprintf(output_fp,"*                   Start time: %s                  *\n",c_time_str);

--- a/src/lapVecNonOrthKpt.c
+++ b/src/lapVecNonOrthKpt.c
@@ -1199,7 +1199,9 @@ void Calc_DX1_DX2_kpt(
             int jshift_X = kshift_X + jj * stride_y_X;
             init1_m1 = init1_m2 = 0;
             const int niters = x_DX_epos - x_DX_spos;
-            #pragma omp simd
+#ifdef ENABLE_SIMD_COMPLEX            
+#pragma omp simd
+#endif            
             for (i = 0; i < niters; i++)
             {
                 int ishift_DX = jshift_DX + i + x_DX_spos;
@@ -1372,7 +1374,9 @@ void stencil_4comp_kpt(
             int jshift_DX = kshift_DX + jjj * stride_y_DX;
             countx = init1 = 0;
             const int niters = x_X1_epos - x_X1_spos;
-            #pragma omp simd
+#ifdef ENABLE_SIMD_COMPLEX            
+#pragma omp simd
+#endif            
             for (i = 0; i < niters; i++)
             {
                 int ishift_X1    = jshift_X1 + i + x_X1_spos;
@@ -1581,7 +1585,9 @@ void stencil_5comp_kpt(
             int jshift_DX2 = kshift_DX2 + jjjj * stride_y_DX2;
             countx = init1_m1 = init1_m2 = 0;
             const int niters = x_X1_epos - x_X1_spos;
-            #pragma omp simd
+#ifdef ENABLE_SIMD_COMPLEX            
+#pragma omp simd
+#endif            
             for (i = 0; i < niters; i++)
             {
                 int ishift_X1  = jshift_X1  + i + x_X1_spos;

--- a/src/lapVecOrthKpt.c
+++ b/src/lapVecOrthKpt.c
@@ -203,7 +203,9 @@ void stencil_3axis_thread_kpt(
             int offset_ex = kp * stride_z_ex + jp * stride_y_ex;
             //global_j = j + DMVertices[2];
             countx = 0;
-            #pragma omp simd
+#ifdef ENABLE_SIMD_COMPLEX            
+#pragma omp simd
+#endif            
             for (i = x_spos; i < x_epos; i++)
             {
                 int ip     = i + shift_ip;

--- a/src/makefile
+++ b/src/makefile
@@ -13,6 +13,10 @@ USE_DP_SUBEIG = 1
 # Set DEBUG_MODE = 1 to run with debug mode and print debug output
 DEBUG_MODE    = 0
 
+# Enable SIMD vectorization for complex stencil routines
+# CAUTION: for some compilers this results in wrong results! Use for intel/19.0.3 or later versions
+ENABLE_SIMD_COMPLEX = 0
+
 # Specify the path MKLROOT if it's not already set to compile with MKL, e.g,
 # MKLROOT = /opt/intel/compilers_and_libraries_2017.4.196/linux/mkl
 
@@ -55,6 +59,11 @@ endif
 # to compile with DEBUG mode
 ifeq ($(DEBUG_MODE), 1)
 CPPFLAGS += -Wall -g -DDEBUG
+endif
+
+# to enable SIMD for complex stencil routines
+ifeq ($(ENABLE_SIMD_COMPLEX), 1)
+CPPFLAGS += -DENABLE_SIMD_COMPLEX
 endif
 
 # for old Intel compiler, use -qopenmp instead of -fopenmp. ICC 17 and later also accepts -fopenmp. 


### PR DESCRIPTION
Add compiling option to enable SIMD vectorization of complex stencil routines (use when intel/19.0.3 or later versions of compilers are available).