### PR TITLE
add command line options -n,-c,-a,-h

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -5,6 +5,17 @@
 
 
 --------------
+Oct 21, 2020
+Name: Qimen Xu
+Changes: (initialization.c, include/isddft.h)
+1. Add command line argument options:
+ (a) -h, --help   Print help massages and exit.
+ (b) -n           Specify number of nodes.
+ (c) -c           Specify number of CPUs per node.
+ (d) -a           Specify number of Accelerators per node, e.g., GPUs.
+
+
+--------------
 Oct 18, 2020
 Name: Qimen Xu
 Changes: (*Kpt.c)

--- a/src/include/isddft.h
+++ b/src/include/isddft.h
@@ -167,6 +167,9 @@ typedef struct _SPARC_OBJ{
     char restartP_Filename[L_STRING];  
     
     /* Parallelizing parameters */
+    int num_node;       // number of processor nodes
+    int num_cpu_per_node; // number of cpu per node
+    int num_acc_per_node; // number of accelerators per node (e.g., GPUs)
     int npspin;         // number of spin communicators
     int npkpt;          // number of processes for paral. over k-points
     int npband;         // number of processes for paral. over bands
@@ -677,6 +680,9 @@ typedef struct _SPARC_OBJ{
  */
 typedef struct _SPARC_INPUT_OBJ{ 
     /* Parallelizing parameters */
+    int num_node;       // number of processor nodes
+    int num_cpu_per_node; // number of cpu per node
+    int num_acc_per_node; // number of accelerators per node (e.g., GPUs)
     int npspin;         // number of spin communicators
     int npkpt;          // number of processes for paral. over k-points
     int npband;         // number of processes for paral. over bands


### PR DESCRIPTION
1. Add command line argument options:
 (a) -h, --help   Print help massages and exit.
 (b) -n           Specify the number of nodes.
 (c) -c           Specify the number of CPUs per node.
 (d) -a           Specify number of Accelerators per node, e.g., GPUs.