### PR TITLE
fix bug in stress printing in .aimd file

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,11 @@
 -Name
 -changes
 
+--------------
+Apr 05, 2021
+Name: Qimen Xu, Abhraj Sharma
+Changes: (md.c)
+1. Fix bug in stress printing in .aimd files, print electronic stress which excludes the ionic contribution.
 
 
 --------------

--- a/src/initialization.c
+++ b/src/initialization.c
@@ -2264,7 +2264,7 @@ void write_output_init(SPARC_OBJ *pSPARC) {
     }
 
     fprintf(output_fp,"***************************************************************************\n");
-    fprintf(output_fp,"*                       SPARC (version Mar 30, 2021)                      *\n");  
+    fprintf(output_fp,"*                       SPARC (version Apr 05, 2021)                      *\n");  
     fprintf(output_fp,"*   Copyright (c) 2020 Material Physics & Mechanics Group, Georgia Tech   *\n");
     fprintf(output_fp,"*           Distributed under GNU General Public License 3 (GPL)          *\n");
     fprintf(output_fp,"*                   Start time: %s                  *\n",c_time_str);

--- a/src/md.c
+++ b/src/md.c
@@ -868,7 +868,10 @@ void Print_fullMD(SPARC_OBJ *pSPARC, FILE *output_md, double *avgvel, double *ma
 	        fprintf(output_md,":STRIO:\n");
 	        PrintStress (pSPARC, pSPARC->stress_i, output_md);
 	        fprintf(output_md,":STRESS:\n");
-	        PrintStress (pSPARC, pSPARC->stress, output_md);
+	        double stress_e[6]; // electronic stress
+            for (int i = 0; i < 6; i++) 
+                stress_e[i] = pSPARC->stress[i] - pSPARC->stress_i[i];
+            PrintStress (pSPARC, stress_e, output_md);
 	    }
 
 	    // print pressure
@@ -1203,3 +1206,4 @@ void Rename_restart(SPARC_OBJ *pSPARC) {
 	if( access(pSPARC->restartC_Filename, F_OK ) != -1 )
 	    rename(pSPARC->restartC_Filename, pSPARC->restartP_Filename);
 }
+


### PR DESCRIPTION
1. Fix bug in stress printing in .aimd files, print electronic stress which excludes the ionic contribution.