### PR TITLE
fix bug in mixing history vectors for spin-polarized calculations

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,14 @@
 -changes
 
 --------------
+Apr 20, 2021
+Name: Qimen Xu
+Changes: (electronicGroundState.c)
+1. Fix bug in mixing history vectors for spin-polarized tests which seriously affects the SCF convergence.
+2. Modify the mixing function so that it's consistent with M-SPARC.
+
+
+--------------
 Apr 19, 2021
 Name: Qimen Xu
 Changes: (readfiles.c, initialization.c, isddft.h)

--- a/src/electronicGroundState.c
+++ b/src/electronicGroundState.c
@@ -465,23 +465,14 @@ void scf(SPARC_OBJ *pSPARC)
             //       struc energy). This is done once SCF is converged. Therefore
             //       the final reported energy is variational.
             if(pSPARC->spin_typ != 0) {
-                for (i = 0; i < NspinDMnd; i++){
-                    temp = pSPARC->electronDens[DMnd + i];
-                    pSPARC->electronDens[DMnd + i] = pSPARC->mixing_hist_xk[i];
-                    pSPARC->mixing_hist_xk[i] = temp;
+                double *rho_in = (double *)malloc(3 * DMnd * sizeof(double));
+                for (int i = 0; i < DMnd; i++) {
+                    rho_in[i] = pSPARC->mixing_hist_xk[i] + pSPARC->mixing_hist_xk[DMnd+i];
+                    rho_in[DMnd+i] = pSPARC->mixing_hist_xk[i];
+                    rho_in[2*DMnd+i] = pSPARC->mixing_hist_xk[DMnd+i];
                 }
-                for (i = 0; i < DMnd; i++)
-                    pSPARC->electronDens[i] = pSPARC->electronDens[DMnd + i] + pSPARC->electronDens[2*DMnd + i];
-
-                Calculate_Free_Energy(pSPARC, pSPARC->electronDens);
-
-                for (i = 0; i < DMnd; i++){
-                    temp = pSPARC->mixing_hist_xk[i];
-                    pSPARC->mixing_hist_xk[i] = pSPARC->electronDens[DMnd + i];
-                    pSPARC->electronDens[DMnd + i] = temp;
-                }
-                for (i = 0; i < DMnd; i++)
-                    pSPARC->electronDens[i] = pSPARC->electronDens[DMnd + i] + pSPARC->electronDens[2*DMnd + i];
+                Calculate_Free_Energy(pSPARC, rho_in);
+                free(rho_in);
             } else
                 Calculate_Free_Energy(pSPARC, pSPARC->mixing_hist_xk);
             

--- a/src/initialization.c
+++ b/src/initialization.c
@@ -2272,7 +2272,7 @@ void write_output_init(SPARC_OBJ *pSPARC) {
     }
 
     fprintf(output_fp,"***************************************************************************\n");
-    fprintf(output_fp,"*                       SPARC (version Apr 19, 2021)                      *\n");  
+    fprintf(output_fp,"*                       SPARC (version Apr 20, 2021)                      *\n");  
     fprintf(output_fp,"*   Copyright (c) 2020 Material Physics & Mechanics Group, Georgia Tech   *\n");
     fprintf(output_fp,"*           Distributed under GNU General Public License 3 (GPL)          *\n");
     fprintf(output_fp,"*                   Start time: %s                  *\n",c_time_str);


### PR DESCRIPTION
1. Fix bug in mixing history vectors for spin-polarized tests which seriously affects the SCF convergence.
2. Modify the mixing function so that it's consistent with M-SPARC.