### PR TITLE
modify memory estimate; reduce memory usage due to MKL for domain-only

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,16 @@
 -Name
 -changes
 
+
+--------------
+Jul 14, 2021
+Name: Qimen Xu
+Changes: (eigenSolver*.c, parallelization.c, initialization.c)
+1. Modify memory estimate (include extra memory used by MKL).
+2. Reduce memory usage due to MKL for domain-only parallelization (NP_BAND_PARAL: 1): skip data transfer through p?gemr2d and explicitly call BLAS ?gemm instead of ScaLAPACK p?gemm for projection.
+3. Move memory allocation of eigmin/eigmax arrays to initialization stage.
+
+
 --------------
 Jul 13, 2021
 Name: Shashikant Kumar

--- a/src/finalization.c
+++ b/src/finalization.c
@@ -150,14 +150,10 @@ void Free_SPARC(SPARC_OBJ *pSPARC) {
 
     #if defined(USE_MKL) || defined(USE_SCALAPACK)
     if (pSPARC->isGammaPoint) {
-        free(pSPARC->Xorb_BLCYC);
-        free(pSPARC->Yorb_BLCYC);
         free(pSPARC->Hp);
         free(pSPARC->Mp);
         free(pSPARC->Q);
     } else {
-        free(pSPARC->Xorb_BLCYC_kpt);
-        free(pSPARC->Yorb_BLCYC_kpt);
         free(pSPARC->Hp_kpt);
         free(pSPARC->Mp_kpt);
         free(pSPARC->Q_kpt);
@@ -167,10 +163,8 @@ void Free_SPARC(SPARC_OBJ *pSPARC) {
     free(pSPARC->forces);
     free(pSPARC->lambda);
     free(pSPARC->occ);
-    if(pSPARC->spincomm_index != -1 && pSPARC->kptcomm_index != -1){
-        free(pSPARC->eigmin);
-        free(pSPARC->eigmax);
-    }  
+    free(pSPARC->eigmin);
+    free(pSPARC->eigmax);
     free(pSPARC->FDweights_D1);
     free(pSPARC->FDweights_D2);
     free(pSPARC->localPsd);

--- a/src/parallelization.c
+++ b/src/parallelization.c
@@ -762,25 +762,6 @@ void Setup_Comms(SPARC_OBJ *pSPARC) {
             pSPARC->desc_orb_BLCYC[i] = 0;
     }
 
-    // allocate memory for block cyclic distribution of orbitals
-    if (pSPARC->isGammaPoint){
-        if (pSPARC->bandcomm_index != -1 && pSPARC->dmcomm != MPI_COMM_NULL) {
-            pSPARC->Xorb_BLCYC = (double *)malloc(pSPARC->nr_orb_BLCYC * pSPARC->nc_orb_BLCYC * sizeof(double));
-            pSPARC->Yorb_BLCYC = (double *)malloc(pSPARC->nr_orb_BLCYC * pSPARC->nc_orb_BLCYC * sizeof(double));
-        } else {
-            pSPARC->Xorb_BLCYC = (double *)malloc(1 * sizeof(double));
-            pSPARC->Yorb_BLCYC = (double *)malloc(1 * sizeof(double));
-        }
-    } else{
-        if (pSPARC->bandcomm_index != -1 && pSPARC->dmcomm != MPI_COMM_NULL) {
-            pSPARC->Xorb_BLCYC_kpt = (double complex *)malloc(pSPARC->nr_orb_BLCYC * pSPARC->nc_orb_BLCYC * sizeof(double complex));
-            pSPARC->Yorb_BLCYC_kpt = (double complex *)malloc(pSPARC->nr_orb_BLCYC * pSPARC->nc_orb_BLCYC * sizeof(double complex));
-        } else {
-            pSPARC->Xorb_BLCYC_kpt = (double complex *)malloc(1 * sizeof(double complex));
-            pSPARC->Yorb_BLCYC_kpt = (double complex *)malloc(1 * sizeof(double complex));
-        }
-    }
-
     // set up distribution of projected Hamiltonian and the corresponding overlap matrix
     // TODO: Find optimal distribution of the projected Hamiltonian and mass matrix!
     //       For now Hp and Mp are distributed as follows: we distribute them in the same
@@ -1029,6 +1010,9 @@ void Setup_Comms(SPARC_OBJ *pSPARC) {
     assert(pSPARC->occ != NULL);
 
     pSPARC->occ_sorted = pSPARC->occ;
+
+    pSPARC->eigmin = (double *) calloc(pSPARC->Nkpts_kptcomm * pSPARC->Nspin_spincomm, sizeof (double));
+    pSPARC->eigmax = (double *) calloc(pSPARC->Nkpts_kptcomm * pSPARC->Nspin_spincomm, sizeof (double));
 
     /* allocate memory for storing atomic forces*/
     pSPARC->forces = (double *)malloc( 3 * pSPARC->n_atom * sizeof(double) );


### PR DESCRIPTION
1. Modify memory estimate (include extra memory used by MKL).
2. Reduce memory usage due to MKL for domain-only parallelization (NP_BAND_PARAL: 1): skip data transfer through p?gemr2d and explicitly call BLAS ?gemm instead of ScaLAPACK p?gemm for projection.
3. Move memory allocation of eigmin/eigmax arrays to initialization stage.
4. Allocate the block-cyclic copy of wavefunctions as needed and on the fly.