### PR TITLE
switch back to calculating pressure directly

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -8,7 +8,7 @@
 Jul 23, 2021
 Name: Qimen Xu
 Changes: (electronicGroundState.c)
-1. Swith back to calculating the pressure directly when CALC_PRES is turned on alone (i.e., CALC_STRESS is off).
+1. Switch back to calculating the pressure directly when CALC_PRES is turned on alone (i.e., CALC_STRESS is off).
 
 
 --------------

--- a/ChangeLog
+++ b/ChangeLog
@@ -5,6 +5,13 @@
 
 
 --------------
+Jul 23, 2021
+Name: Qimen Xu
+Changes: (electronicGroundState.c)
+1. Swith back to calculating the pressure directly when CALC_PRES is turned on alone (i.e., CALC_STRESS is off).
+
+
+--------------
 Jul 14, 2021
 Name: Qimen Xu
 Changes: (eigenSolver*.c, parallelization.c, initialization.c)

--- a/src/electronicGroundState.c
+++ b/src/electronicGroundState.c
@@ -140,7 +140,7 @@ void Calculate_electronicGroundState(SPARC_OBJ *pSPARC) {
     }
     
     // Calculate Stress and pressure
-    if(pSPARC->Calc_stress == 1 || pSPARC->Calc_pres == 1){
+    if(pSPARC->Calc_stress == 1){
         t1 = MPI_Wtime();
         Calculate_electronic_stress(pSPARC);
         t2 = MPI_Wtime();
@@ -175,7 +175,7 @@ void Calculate_electronicGroundState(SPARC_OBJ *pSPARC) {
             fprintf(output_fp,"Time for stress calculation        :  %.3f (sec)\n",t2-t1);
             fclose(output_fp);
         }
-    } else if(pSPARC->Calc_pres == 1){ // obsolete, will calculate stress tensor instead
+    } else if(pSPARC->Calc_pres == 1){
         t1 = MPI_Wtime();
         Calculate_electronic_pressure(pSPARC);
         t2 = MPI_Wtime();

--- a/src/initialization.c
+++ b/src/initialization.c
@@ -2324,7 +2324,7 @@ void write_output_init(SPARC_OBJ *pSPARC) {
     }
 
     fprintf(output_fp,"***************************************************************************\n");
-    fprintf(output_fp,"*                       SPARC (version Jul 14, 2021)                      *\n");  
+    fprintf(output_fp,"*                       SPARC (version Jul 23, 2021)                      *\n");  
     fprintf(output_fp,"*   Copyright (c) 2020 Material Physics & Mechanics Group, Georgia Tech   *\n");
     fprintf(output_fp,"*           Distributed under GNU General Public License 3 (GPL)          *\n");
     fprintf(output_fp,"*                   Start time: %s                  *\n",c_time_str);


### PR DESCRIPTION
1. Switch back to calculating the pressure directly when `CALC_PRES` is turned on alone (i.e., CALC_STRESS is off).