### PR TITLE
flush stdout to prevent finalize hang; print all stdout by rank 0

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,15 @@
 -Name
 -changes
 
+
+--------------
+Oct 03, 2021
+Name: Qimen Xu
+Changes: (main.c, initialization.c, md.c, relax.c)
+1. Explicitly flush the standard output right before MPI_Finalization to prevent Finalize hang.
+2. In DEBUG mode, make sure all standard output are printed by rank 0.
+
+
 --------------
 Sep 22, 2021
 Name: Xin Jing

--- a/src/initialization.c
+++ b/src/initialization.c
@@ -174,7 +174,7 @@ void Initialize(SPARC_OBJ *pSPARC, int argc, char *argv[]) {
         MPI_Bcast(&SPARC_Input, 1, SPARC_INPUT_MPI, 0, MPI_COMM_WORLD);
 #ifdef DEBUG
         t2 = MPI_Wtime();
-        if (rank == 1) printf("Broadcasting the input parameters took %.3f ms\n",(t2-t1)*1000);
+        if (rank == 0) printf("Broadcasting the input parameters took %.3f ms\n",(t2-t1)*1000);
 #endif
         // broadcast Ntypes read from ion file
         MPI_Ibcast(&pSPARC->Ntypes, 1, MPI_INT, 0, MPI_COMM_WORLD, &req);
@@ -581,7 +581,7 @@ void bcast_SPARC_Atom(SPARC_OBJ *pSPARC) {
 
 #ifdef DEBUG
         t2 = MPI_Wtime();
-        if (rank == 1) printf("Bcast pre-info. took %.3f ms\n", (t2-t1)*1000);
+        if (rank == 0) printf("Bcast pre-info. took %.3f ms\n", (t2-t1)*1000);
 #endif
         // unpack info.
         pSPARC->n_atom = tempbuff[0];
@@ -727,7 +727,7 @@ void bcast_SPARC_Atom(SPARC_OBJ *pSPARC) {
         MPI_Bcast(buff, l_buff, MPI_PACKED, 0, MPI_COMM_WORLD);
 #ifdef DEBUG
         t2 = MPI_Wtime();
-        if (rank == 1) printf("MPI_Bcast packed buff of length %d took %.3f ms\n", l_buff,(t2-t1)*1000);
+        if (rank == 0) printf("MPI_Bcast packed buff of length %d took %.3f ms\n", l_buff,(t2-t1)*1000);
 #endif
         // unpack the variables
         position = 0;
@@ -2324,7 +2324,7 @@ void write_output_init(SPARC_OBJ *pSPARC) {
     }
 
     fprintf(output_fp,"***************************************************************************\n");
-    fprintf(output_fp,"*                       SPARC (version Sep 22, 2021)                      *\n");  
+    fprintf(output_fp,"*                       SPARC (version Oct 03, 2021)                      *\n");  
     fprintf(output_fp,"*   Copyright (c) 2020 Material Physics & Mechanics Group, Georgia Tech   *\n");
     fprintf(output_fp,"*           Distributed under GNU General Public License 3 (GPL)          *\n");
     fprintf(output_fp,"*                   Start time: %s                  *\n",c_time_str);

--- a/src/main.c
+++ b/src/main.c
@@ -57,7 +57,10 @@ int main(int argc, char *argv[]) {
     if (rank == 0) {
         printf("The program took %.3f s.\n", t2 - t1); 
     }
-    
+
+    // ensure stdout flushed to prevent Finalize hang
+    fflush(stdout);
+
     // finalize MPI
     MPI_Finalize();
     return 0;

--- a/src/md.c
+++ b/src/md.c
@@ -1178,7 +1178,7 @@ void RestartMD(SPARC_OBJ *pSPARC) {
         MPI_Bcast(buff, l_buff, MPI_PACKED, 0, MPI_COMM_WORLD);
 #ifdef DEBUG
         t2 = MPI_Wtime();
-        if (rank == 1) printf(GRN "MPI_Bcast (.restart MD) packed buff of length %d took %.3f ms\n" RESET, l_buff,(t2-t1)*1000);
+        if (rank == 0) printf(GRN "MPI_Bcast (.restart MD) packed buff of length %d took %.3f ms\n" RESET, l_buff,(t2-t1)*1000);
 #endif
 		// unpack the variables
         position = 0;

--- a/src/relax.c
+++ b/src/relax.c
@@ -1635,7 +1635,7 @@ void RestartRelax(SPARC_OBJ *pSPARC) {
         MPI_Bcast(buff, l_buff, MPI_PACKED, 0, MPI_COMM_WORLD);
 #ifdef DEBUG
         t2 = MPI_Wtime();
-        if (rank == 1) printf(GRN "MPI_Bcast (.restart relax) packed buff of length %d took %.3f ms\n" RESET, l_buff,(t2-t1)*1000);
+        if (rank == 0) printf(GRN "MPI_Bcast (.restart relax) packed buff of length %d took %.3f ms\n" RESET, l_buff,(t2-t1)*1000);
 #endif
         // unpack the variables
         position = 0;


### PR DESCRIPTION
* Explicitly flush the standard output right before MPI_Finalization to prevent Finalize hang.
* In DEBUG mode, make sure all standard output is printed by rank 0.