### PR TITLE
Fix bug in NLCC for spin-polarized relaxation/MD simulations

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -5,7 +5,7 @@
 
 
 --------------
-Nov 18, 2021
+Nov 19, 2021
 Name: Qimen Xu
 Changes: (electrostatics.c)
 1. Fix bug in NLCC for spin-polarized relaxation/MD simulations.

--- a/ChangeLog
+++ b/ChangeLog
@@ -5,6 +5,13 @@
 
 
 --------------
+Nov 18, 2021
+Name: Qimen Xu
+Changes: (electrostatics.c)
+1. Fix bug in NLCC for spin-polarized relaxation/MD simulations.
+
+
+--------------
 Oct 28, 2021
 Name: Shashikant Kumar
 Changes: (tests)

--- a/src/electrostatics.c
+++ b/src/electrostatics.c
@@ -788,6 +788,7 @@ void Generate_PseudoChargeDensity(SPARC_OBJ *pSPARC) {
     for (spn_i = 1; spn_i < 2*pSPARC->Nspin-1; spn_i++) {
         for (i = 0; i < DMnd; i++) {
             pSPARC->electronDens_at[spn_i*DMnd + i] = 0.0;
+            pSPARC->electronDens_core[spn_i*DMnd + i] = 0.0;
         }
     }
 

--- a/src/initialization.c
+++ b/src/initialization.c
@@ -2324,7 +2324,7 @@ void write_output_init(SPARC_OBJ *pSPARC) {
     }
 
     fprintf(output_fp,"***************************************************************************\n");
-    fprintf(output_fp,"*                       SPARC (version Nov 18, 2021)                      *\n");
+    fprintf(output_fp,"*                       SPARC (version Nov 19, 2021)                      *\n");
     fprintf(output_fp,"*   Copyright (c) 2020 Material Physics & Mechanics Group, Georgia Tech   *\n");
     fprintf(output_fp,"*           Distributed under GNU General Public License 3 (GPL)          *\n");
     fprintf(output_fp,"*                   Start time: %s                  *\n",c_time_str);

--- a/src/initialization.c
+++ b/src/initialization.c
@@ -2324,7 +2324,7 @@ void write_output_init(SPARC_OBJ *pSPARC) {
     }
 
     fprintf(output_fp,"***************************************************************************\n");
-    fprintf(output_fp,"*                       SPARC (version Oct 11, 2021)                      *\n");
+    fprintf(output_fp,"*                       SPARC (version Nov 18, 2021)                      *\n");
     fprintf(output_fp,"*   Copyright (c) 2020 Material Physics & Mechanics Group, Georgia Tech   *\n");
     fprintf(output_fp,"*           Distributed under GNU General Public License 3 (GPL)          *\n");
     fprintf(output_fp,"*                   Start time: %s                  *\n",c_time_str);


### PR DESCRIPTION
* re-initialize spin-up and spin-down core electron densities.