### PR TITLE
add hard-coded order orth Lap/Grad stencils for 12th FD order

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -21,6 +21,13 @@ Changes: (xc/vdW/d3, xc/vdW/vdWDF, xc/mgga, stress.c, pressure.c)
 
 
 --------------
+Jul 18, 2022
+Name: Qimen Xu
+Changes: (gradVecRoutines.c, lapVecOrth.c)
+1. When the FD order = `8, 12, 16`, use a hard-coded version of the (orthogonal, gamma-point) stencil to improve its efficiency.
+
+
+--------------
 Jul 14, 2022
 Name: Xin Jing
 Changes: (exx/, sq/, initialization.c, tests/)

--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,14 @@
 -Name
 -changes
 
+
+--------------
+Jul 18, 2022
+Name: Qimen Xu
+Changes: (gradVecRoutines.c, lapVecOrth.c)
+1. When the FD order = `8, 12, 16`, use a hard-coded version of the (orthogonal, gamma-point) stencil to improve its efficiency.
+
+
 --------------
 Jul 18, 2022
 Name: Shashikant Kumar
@@ -13,18 +21,12 @@ Changes: (tests)
 4. add option to update reference files
 5. option to run on any general cluster
 
+
 --------------
 Jul 15, 2022
 Name: Boqin Zhang
 Changes: (xc/vdW/d3, xc/vdW/vdWDF, xc/mgga, stress.c, pressure.c)
 1. Split DFT-D3, vdWDF and metaGGA files into multiple files
-
-
---------------
-Jul 18, 2022
-Name: Qimen Xu
-Changes: (gradVecRoutines.c, lapVecOrth.c)
-1. When the FD order = `8, 12, 16`, use a hard-coded version of the (orthogonal, gamma-point) stencil to improve its efficiency.
 
 
 --------------

--- a/ChangeLog
+++ b/ChangeLog
@@ -5,10 +5,10 @@
 
 
 --------------
-Jul 18, 2022
+Jul 19, 2022
 Name: Qimen Xu
 Changes: (gradVecRoutines.c, lapVecOrth.c)
-1. When the FD order = `8, 12, 16`, use a hard-coded version of the (orthogonal, gamma-point) stencil to improve its efficiency.
+1. When the FD order = `12`, use a hard-coded version of the (orthogonal, gamma-point) stencil to improve its efficiency.
 
 
 --------------

--- a/src/gradVecRoutines.c
+++ b/src/gradVecRoutines.c
@@ -352,12 +352,12 @@ void Gradient_vec_dir(const SPARC_OBJ *pSPARC, const int DMnd, const int *DMVert
 /*  
  * @brief: function to calculate derivative
  */
-void Calc_DX(
+void Calc_DX_variable_radius(
     const double *X,       double *DX,
     const int radius,      const int stride_X,
-    const int stride_y_X,  const int stride_y_DX, 
+    const int stride_y_X,  const int stride_y_DX,
     const int stride_z_X,  const int stride_z_DX,
-    const int x_DX_spos,   const int x_DX_epos, 
+    const int x_DX_spos,   const int x_DX_epos,
     const int y_DX_spos,   const int y_DX_epos,
     const int z_DX_spos,   const int z_DX_epos,
     const int x_X_spos,    const int y_X_spos,
@@ -370,7 +370,7 @@ void Calc_DX(
     for (k = z_DX_spos, kk = z_X_spos; k < z_DX_epos; k++, kk++)
     {
         int kshift_DX = k * stride_z_DX;
-        int kshift_X = kk * stride_z_X;        
+        int kshift_X = kk * stride_z_X;
         for (j = y_DX_spos, jj = y_X_spos; j < y_DX_epos; j++, jj++)
         {
             int jshift_DX = kshift_DX + j * stride_y_DX;
@@ -395,3 +395,191 @@ void Calc_DX(
         }
     }
 }
+
+
+void Calc_DX_radius4(
+    const double *X,       double *DX,
+    const int radius,      const int stride_X,
+    const int stride_y_X,  const int stride_y_DX,
+    const int stride_z_X,  const int stride_z_DX,
+    const int x_DX_spos,   const int x_DX_epos,
+    const int y_DX_spos,   const int y_DX_epos,
+    const int z_DX_spos,   const int z_DX_epos,
+    const int x_X_spos,    const int y_X_spos,
+    const int z_X_spos,    const double *stencil_coefs,
+    const double c
+)
+{
+    int i, j, k, jj, kk, r;
+    
+    for (k = z_DX_spos, kk = z_X_spos; k < z_DX_epos; k++, kk++)
+    {
+        int kshift_DX = k * stride_z_DX;
+        int kshift_X = kk * stride_z_X;
+        for (j = y_DX_spos, jj = y_X_spos; j < y_DX_epos; j++, jj++)
+        {
+            int jshift_DX = kshift_DX + j * stride_y_DX;
+            int jshift_X = kshift_X + jj * stride_y_X;
+            const int niters = x_DX_epos - x_DX_spos;
+            #pragma omp simd
+            //for (i = x_DX_spos, ii = x_X_spos; i < x_DX_epos; i++, ii++)
+            for (i = 0; i < niters; i++)
+            {
+                int ishift_DX = jshift_DX + i + x_DX_spos;
+                int ishift_X = jshift_X + i + x_X_spos;
+                double temp = X[ishift_X] * c;
+                for (r = 1; r <= 4; r++)
+                {
+                    int stride_X_r = r * stride_X;
+                    temp += (X[ishift_X + stride_X_r] - X[ishift_X - stride_X_r]) * stencil_coefs[r];
+                }
+                DX[ishift_DX] = temp;
+            }
+        }
+    }
+}
+
+
+void Calc_DX_radius6(
+    const double *X,       double *DX,
+    const int radius,      const int stride_X,
+    const int stride_y_X,  const int stride_y_DX,
+    const int stride_z_X,  const int stride_z_DX,
+    const int x_DX_spos,   const int x_DX_epos,
+    const int y_DX_spos,   const int y_DX_epos,
+    const int z_DX_spos,   const int z_DX_epos,
+    const int x_X_spos,    const int y_X_spos,
+    const int z_X_spos,    const double *stencil_coefs,
+    const double c
+)
+{
+    int i, j, k, jj, kk, r;
+    
+    for (k = z_DX_spos, kk = z_X_spos; k < z_DX_epos; k++, kk++)
+    {
+        int kshift_DX = k * stride_z_DX;
+        int kshift_X = kk * stride_z_X;
+        for (j = y_DX_spos, jj = y_X_spos; j < y_DX_epos; j++, jj++)
+        {
+            int jshift_DX = kshift_DX + j * stride_y_DX;
+            int jshift_X = kshift_X + jj * stride_y_X;
+            const int niters = x_DX_epos - x_DX_spos;
+            #pragma omp simd
+            //for (i = x_DX_spos, ii = x_X_spos; i < x_DX_epos; i++, ii++)
+            for (i = 0; i < niters; i++)
+            {
+                int ishift_DX = jshift_DX + i + x_DX_spos;
+                int ishift_X = jshift_X + i + x_X_spos;
+                double temp = X[ishift_X] * c;
+                for (r = 1; r <= 6; r++)
+                {
+                    int stride_X_r = r * stride_X;
+                    temp += (X[ishift_X + stride_X_r] - X[ishift_X - stride_X_r]) * stencil_coefs[r];
+                }
+                DX[ishift_DX] = temp;
+            }
+        }
+    }
+}
+
+
+void Calc_DX_radius8(
+    const double *X,       double *DX,
+    const int radius,      const int stride_X,
+    const int stride_y_X,  const int stride_y_DX, 
+    const int stride_z_X,  const int stride_z_DX,
+    const int x_DX_spos,   const int x_DX_epos,
+    const int y_DX_spos,   const int y_DX_epos,
+    const int z_DX_spos,   const int z_DX_epos,
+    const int x_X_spos,    const int y_X_spos,
+    const int z_X_spos,    const double *stencil_coefs,
+    const double c
+)
+{
+    int i, j, k, jj, kk, r;
+    
+    for (k = z_DX_spos, kk = z_X_spos; k < z_DX_epos; k++, kk++)
+    {
+        int kshift_DX = k * stride_z_DX;
+        int kshift_X = kk * stride_z_X;
+        for (j = y_DX_spos, jj = y_X_spos; j < y_DX_epos; j++, jj++)
+        {
+            int jshift_DX = kshift_DX + j * stride_y_DX;
+            int jshift_X = kshift_X + jj * stride_y_X;
+            const int niters = x_DX_epos - x_DX_spos;
+            #pragma omp simd
+            //for (i = x_DX_spos, ii = x_X_spos; i < x_DX_epos; i++, ii++)
+            for (i = 0; i < niters; i++)
+            {
+                int ishift_DX = jshift_DX + i + x_DX_spos;
+                int ishift_X = jshift_X + i + x_X_spos;
+                double temp = X[ishift_X] * c;
+                for (r = 1; r <= 8; r++)
+                {
+                    int stride_X_r = r * stride_X;
+                    temp += (X[ishift_X + stride_X_r] - X[ishift_X - stride_X_r]) * stencil_coefs[r];
+                }
+                DX[ishift_DX] = temp;
+            }
+        }
+    }
+}
+
+
+
+/*  
+ * @brief: function to calculate derivative
+ */
+void Calc_DX(
+    const double *X,       double *DX,
+    const int radius,      const int stride_X,
+    const int stride_y_X,  const int stride_y_DX,
+    const int stride_z_X,  const int stride_z_DX,
+    const int x_DX_spos,   const int x_DX_epos,
+    const int y_DX_spos,   const int y_DX_epos,
+    const int z_DX_spos,   const int z_DX_epos,
+    const int x_X_spos,    const int y_X_spos,
+    const int z_X_spos,    const double *stencil_coefs,
+    const double c
+)
+{
+    switch (radius)
+    {
+        case 4:
+            Calc_DX_radius4(
+                X, DX, radius, stride_X, stride_y_X, stride_y_DX, stride_z_X, stride_z_DX,
+                x_DX_spos, x_DX_epos, y_DX_spos, y_DX_epos, z_DX_spos, z_DX_epos,
+                x_X_spos, y_X_spos, z_X_spos, stencil_coefs, c
+            );
+            return;
+            break;
+
+        case 6:
+            Calc_DX_radius6(
+                X, DX, radius, stride_X, stride_y_X, stride_y_DX, stride_z_X, stride_z_DX,
+                x_DX_spos, x_DX_epos, y_DX_spos, y_DX_epos, z_DX_spos, z_DX_epos,
+                x_X_spos, y_X_spos, z_X_spos, stencil_coefs, c
+            );
+            return;
+            break;
+
+        case 8:
+            Calc_DX_radius8(
+                X, DX, radius, stride_X, stride_y_X, stride_y_DX, stride_z_X, stride_z_DX,
+                x_DX_spos, x_DX_epos, y_DX_spos, y_DX_epos, z_DX_spos, z_DX_epos,
+                x_X_spos, y_X_spos, z_X_spos, stencil_coefs, c
+            );
+            return;
+            break;
+
+        default:
+            Calc_DX_variable_radius(
+                X, DX, radius, stride_X, stride_y_X, stride_y_DX, stride_z_X, stride_z_DX,
+                x_DX_spos, x_DX_epos, y_DX_spos, y_DX_epos, z_DX_spos, z_DX_epos,
+                x_X_spos, y_X_spos, z_X_spos, stencil_coefs, c
+            );
+            return;
+            break;
+    }
+}
+

--- a/src/gradVecRoutines.c
+++ b/src/gradVecRoutines.c
@@ -397,49 +397,6 @@ void Calc_DX_variable_radius(
 }
 
 
-void Calc_DX_radius4(
-    const double *X,       double *DX,
-    const int radius,      const int stride_X,
-    const int stride_y_X,  const int stride_y_DX,
-    const int stride_z_X,  const int stride_z_DX,
-    const int x_DX_spos,   const int x_DX_epos,
-    const int y_DX_spos,   const int y_DX_epos,
-    const int z_DX_spos,   const int z_DX_epos,
-    const int x_X_spos,    const int y_X_spos,
-    const int z_X_spos,    const double *stencil_coefs,
-    const double c
-)
-{
-    int i, j, k, jj, kk, r;
-    
-    for (k = z_DX_spos, kk = z_X_spos; k < z_DX_epos; k++, kk++)
-    {
-        int kshift_DX = k * stride_z_DX;
-        int kshift_X = kk * stride_z_X;
-        for (j = y_DX_spos, jj = y_X_spos; j < y_DX_epos; j++, jj++)
-        {
-            int jshift_DX = kshift_DX + j * stride_y_DX;
-            int jshift_X = kshift_X + jj * stride_y_X;
-            const int niters = x_DX_epos - x_DX_spos;
-            #pragma omp simd
-            //for (i = x_DX_spos, ii = x_X_spos; i < x_DX_epos; i++, ii++)
-            for (i = 0; i < niters; i++)
-            {
-                int ishift_DX = jshift_DX + i + x_DX_spos;
-                int ishift_X = jshift_X + i + x_X_spos;
-                double temp = X[ishift_X] * c;
-                for (r = 1; r <= 4; r++)
-                {
-                    int stride_X_r = r * stride_X;
-                    temp += (X[ishift_X + stride_X_r] - X[ishift_X - stride_X_r]) * stencil_coefs[r];
-                }
-                DX[ishift_DX] = temp;
-            }
-        }
-    }
-}
-
-
 void Calc_DX_radius6(
     const double *X,       double *DX,
     const int radius,      const int stride_X,
@@ -483,50 +440,6 @@ void Calc_DX_radius6(
 }
 
 
-void Calc_DX_radius8(
-    const double *X,       double *DX,
-    const int radius,      const int stride_X,
-    const int stride_y_X,  const int stride_y_DX, 
-    const int stride_z_X,  const int stride_z_DX,
-    const int x_DX_spos,   const int x_DX_epos,
-    const int y_DX_spos,   const int y_DX_epos,
-    const int z_DX_spos,   const int z_DX_epos,
-    const int x_X_spos,    const int y_X_spos,
-    const int z_X_spos,    const double *stencil_coefs,
-    const double c
-)
-{
-    int i, j, k, jj, kk, r;
-    
-    for (k = z_DX_spos, kk = z_X_spos; k < z_DX_epos; k++, kk++)
-    {
-        int kshift_DX = k * stride_z_DX;
-        int kshift_X = kk * stride_z_X;
-        for (j = y_DX_spos, jj = y_X_spos; j < y_DX_epos; j++, jj++)
-        {
-            int jshift_DX = kshift_DX + j * stride_y_DX;
-            int jshift_X = kshift_X + jj * stride_y_X;
-            const int niters = x_DX_epos - x_DX_spos;
-            #pragma omp simd
-            //for (i = x_DX_spos, ii = x_X_spos; i < x_DX_epos; i++, ii++)
-            for (i = 0; i < niters; i++)
-            {
-                int ishift_DX = jshift_DX + i + x_DX_spos;
-                int ishift_X = jshift_X + i + x_X_spos;
-                double temp = X[ishift_X] * c;
-                for (r = 1; r <= 8; r++)
-                {
-                    int stride_X_r = r * stride_X;
-                    temp += (X[ishift_X + stride_X_r] - X[ishift_X - stride_X_r]) * stencil_coefs[r];
-                }
-                DX[ishift_DX] = temp;
-            }
-        }
-    }
-}
-
-
-
 /*  
  * @brief: function to calculate derivative
  */
@@ -545,26 +458,8 @@ void Calc_DX(
 {
     switch (radius)
     {
-        case 4:
-            Calc_DX_radius4(
-                X, DX, radius, stride_X, stride_y_X, stride_y_DX, stride_z_X, stride_z_DX,
-                x_DX_spos, x_DX_epos, y_DX_spos, y_DX_epos, z_DX_spos, z_DX_epos,
-                x_X_spos, y_X_spos, z_X_spos, stencil_coefs, c
-            );
-            return;
-            break;
-
         case 6:
             Calc_DX_radius6(
-                X, DX, radius, stride_X, stride_y_X, stride_y_DX, stride_z_X, stride_z_DX,
-                x_DX_spos, x_DX_epos, y_DX_spos, y_DX_epos, z_DX_spos, z_DX_epos,
-                x_X_spos, y_X_spos, z_X_spos, stencil_coefs, c
-            );
-            return;
-            break;
-
-        case 8:
-            Calc_DX_radius8(
                 X, DX, radius, stride_X, stride_y_X, stride_y_DX, stride_z_X, stride_z_DX,
                 x_DX_spos, x_DX_epos, y_DX_spos, y_DX_epos, z_DX_spos, z_DX_epos,
                 x_X_spos, y_X_spos, z_X_spos, stencil_coefs, c

--- a/src/initialization.c
+++ b/src/initialization.c
@@ -3104,7 +3104,7 @@ void write_output_init(SPARC_OBJ *pSPARC) {
     }
 
     fprintf(output_fp,"***************************************************************************\n");
-    fprintf(output_fp,"*                       SPARC (version Jul 15, 2022)                      *\n");
+    fprintf(output_fp,"*                       SPARC (version Jul 18, 2022)                      *\n");
     fprintf(output_fp,"*   Copyright (c) 2020 Material Physics & Mechanics Group, Georgia Tech   *\n");
     fprintf(output_fp,"*           Distributed under GNU General Public License 3 (GPL)          *\n");
     fprintf(output_fp,"*                   Start time: %s                  *\n",c_time_str);

--- a/src/initialization.c
+++ b/src/initialization.c
@@ -3104,7 +3104,7 @@ void write_output_init(SPARC_OBJ *pSPARC) {
     }
 
     fprintf(output_fp,"***************************************************************************\n");
-    fprintf(output_fp,"*                       SPARC (version Jul 18, 2022)                      *\n");
+    fprintf(output_fp,"*                       SPARC (version Jul 19, 2022)                      *\n");
     fprintf(output_fp,"*   Copyright (c) 2020 Material Physics & Mechanics Group, Georgia Tech   *\n");
     fprintf(output_fp,"*           Distributed under GNU General Public License 3 (GPL)          *\n");
     fprintf(output_fp,"*                   Start time: %s                  *\n",c_time_str);

--- a/src/lapVecOrth.c
+++ b/src/lapVecOrth.c
@@ -83,7 +83,7 @@ void Lap_vec_mult_orth(
  *
  * Copyright (c) 2018-2019 Edmond Group at Georgia Tech.
  */
-void stencil_3axis_thread_v2(
+void stencil_3axis_thread_variable_radius(
     const double *x0,    const int radius, 
     const int stride_y,  const int stride_y_ex, 
     const int stride_z,  const int stride_z_ex,
@@ -128,9 +128,143 @@ void stencil_3axis_thread_v2(
 }
 
 
+void stencil_3axis_thread_radius6(
+    const double *x0,    const int radius, 
+    const int stride_y,  const int stride_y_ex, 
+    const int stride_z,  const int stride_z_ex,
+    const int x_spos,    const int x_epos, 
+    const int y_spos,    const int y_epos,
+    const int z_spos,    const int z_epos,
+    const int x_ex_spos, const int y_ex_spos,  // this allows us to give x as x0 for 
+    const int z_ex_spos,                       // calc inner part of Lx
+    const double *stencil_coefs, 
+    const double coef_0, const double b,   
+    const double *v0,    double *y
+)
+{
+    int i, j, k, jp, kp, r;
+    const int shift_ip = x_ex_spos - x_spos;
+    for (k = z_spos, kp = z_ex_spos; k < z_epos; k++, kp++)
+    {
+        for (j = y_spos, jp = y_ex_spos; j < y_epos; j++, jp++)
+        {
+            int offset = k * stride_z + j * stride_y;
+            int offset_ex = kp * stride_z_ex + jp * stride_y_ex;
+            #pragma omp simd
+            for (i = x_spos; i < x_epos; i++)
+            {
+                int ip     = i + shift_ip;
+                int idx    = offset + i;
+                int idx_ex = offset_ex + ip;
+                double res = coef_0 * x0[idx_ex];
+                for (r = 1; r <= 6; r++)
+                {
+                    int stride_y_r = r * stride_y_ex;
+                    int stride_z_r = r * stride_z_ex;
+                    double res_x = (x0[idx_ex - r]          + x0[idx_ex + r])          * stencil_coefs[3*r];
+                    double res_y = (x0[idx_ex - stride_y_r] + x0[idx_ex + stride_y_r]) * stencil_coefs[3*r+1];
+                    double res_z = (x0[idx_ex - stride_z_r] + x0[idx_ex + stride_z_r]) * stencil_coefs[3*r+2];
+                    res += res_x + res_y + res_z;
+                }
+                y[idx] = res + b * (v0[idx] * x0[idx_ex]); 
+            }
+        }
+    }
+}
+
+
+void stencil_3axis_thread_radius4(
+    const double *x0,    const int radius, 
+    const int stride_y,  const int stride_y_ex, 
+    const int stride_z,  const int stride_z_ex,
+    const int x_spos,    const int x_epos, 
+    const int y_spos,    const int y_epos,
+    const int z_spos,    const int z_epos,
+    const int x_ex_spos, const int y_ex_spos,  // this allows us to give x as x0 for 
+    const int z_ex_spos,                       // calc inner part of Lx
+    const double *stencil_coefs, 
+    const double coef_0, const double b,   
+    const double *v0,    double *y
+)
+{
+    int i, j, k, jp, kp, r;
+    const int shift_ip = x_ex_spos - x_spos;
+    for (k = z_spos, kp = z_ex_spos; k < z_epos; k++, kp++)
+    {
+        for (j = y_spos, jp = y_ex_spos; j < y_epos; j++, jp++)
+        {
+            int offset = k * stride_z + j * stride_y;
+            int offset_ex = kp * stride_z_ex + jp * stride_y_ex;
+            #pragma omp simd
+            for (i = x_spos; i < x_epos; i++)
+            {
+                int ip     = i + shift_ip;
+                int idx    = offset + i;
+                int idx_ex = offset_ex + ip;
+                double res = coef_0 * x0[idx_ex];
+                for (r = 1; r <= 4; r++)
+                {
+                    int stride_y_r = r * stride_y_ex;
+                    int stride_z_r = r * stride_z_ex;
+                    double res_x = (x0[idx_ex - r]          + x0[idx_ex + r])          * stencil_coefs[3*r];
+                    double res_y = (x0[idx_ex - stride_y_r] + x0[idx_ex + stride_y_r]) * stencil_coefs[3*r+1];
+                    double res_z = (x0[idx_ex - stride_z_r] + x0[idx_ex + stride_z_r]) * stencil_coefs[3*r+2];
+                    res += res_x + res_y + res_z;
+                }
+                y[idx] = res + b * (v0[idx] * x0[idx_ex]); 
+            }
+        }
+    }
+}
+
+
+void stencil_3axis_thread_radius8(
+    const double *x0,    const int radius, 
+    const int stride_y,  const int stride_y_ex, 
+    const int stride_z,  const int stride_z_ex,
+    const int x_spos,    const int x_epos, 
+    const int y_spos,    const int y_epos,
+    const int z_spos,    const int z_epos,
+    const int x_ex_spos, const int y_ex_spos,  // this allows us to give x as x0 for 
+    const int z_ex_spos,                       // calc inner part of Lx
+    const double *stencil_coefs, 
+    const double coef_0, const double b,   
+    const double *v0,    double *y
+)
+{
+    int i, j, k, jp, kp, r;
+    const int shift_ip = x_ex_spos - x_spos;
+    for (k = z_spos, kp = z_ex_spos; k < z_epos; k++, kp++)
+    {
+        for (j = y_spos, jp = y_ex_spos; j < y_epos; j++, jp++)
+        {
+            int offset = k * stride_z + j * stride_y;
+            int offset_ex = kp * stride_z_ex + jp * stride_y_ex;
+            #pragma omp simd
+            for (i = x_spos; i < x_epos; i++)
+            {
+                int ip     = i + shift_ip;
+                int idx    = offset + i;
+                int idx_ex = offset_ex + ip;
+                double res = coef_0 * x0[idx_ex];
+                for (r = 1; r <= 8; r++)
+                {
+                    int stride_y_r = r * stride_y_ex;
+                    int stride_z_r = r * stride_z_ex;
+                    double res_x = (x0[idx_ex - r]          + x0[idx_ex + r])          * stencil_coefs[3*r];
+                    double res_y = (x0[idx_ex - stride_y_r] + x0[idx_ex + stride_y_r]) * stencil_coefs[3*r+1];
+                    double res_z = (x0[idx_ex - stride_z_r] + x0[idx_ex + stride_z_r]) * stencil_coefs[3*r+2];
+                    res += res_x + res_y + res_z;
+                }
+                y[idx] = res + b * (v0[idx] * x0[idx_ex]); 
+            }
+        }
+    }
+}
+
 
 /**
- * @brief   Kernel for calculating y = (a * Lap + b * diag(v0) + c * I) * x + beta * y.
+ * @brief   Kernel for calculating y = (a * Lap + b * diag(v0) + c * I) * x.
  *          For the input & output domain, z/x index is the slowest/fastest running index
  *
  * @param x0               : Input domain with extended boundary 
@@ -155,14 +289,8 @@ void stencil_3axis_thread_v2(
  * @param beta             : Scaling factor of y
  * @param y (OUT)          : Output domain with original boundary
  *
- * @author  Hua Huang <huangh223@gatech.edu>
- *          Edmond Chow <echow@cc.gatech.edu>
- *
- * @modified by Qimen Xu <qimenxu@gatech.edu>, Mar 2019, Georgia Tech
- *
- * Copyright (c) 2018-2019 Edmond Group at Georgia Tech.
  */
-void stencil_3axis_thread_v1(
+void stencil_3axis_thread_v2(
     const double *x0,    const int radius, 
     const int stride_y,  const int stride_y_ex, 
     const int stride_z,  const int stride_z_ex,
@@ -173,38 +301,47 @@ void stencil_3axis_thread_v1(
     const int z_ex_spos,                       // calc inner part of Lx
     const double *stencil_coefs, 
     const double coef_0, const double b,   
-    const double *v0,    const double beta, 
-    double *y
+    const double *v0,    double *y
 )
 {
-    int i, j, k, jp, kp, r;
-    const int shift_ip = x_ex_spos - x_spos;
-    for (k = z_spos, kp = z_ex_spos; k < z_epos; k++, kp++)
+    switch (radius)
     {
-        for (j = y_spos, jp = y_ex_spos; j < y_epos; j++, jp++)
-        {
-            int offset = k * stride_z + j * stride_y;
-            int offset_ex = kp * stride_z_ex + jp * stride_y_ex;
-            #pragma omp simd
-            for (i = x_spos; i < x_epos; i++)
-            {
-                int ip     = i + shift_ip;
-                int idx    = offset + i;
-                int idx_ex = offset_ex + ip;
-                double res = coef_0 * x0[idx_ex];
-                for (r = 1; r <= radius; r++)
-                {
-                    int stride_y_r = r * stride_y_ex;
-                    int stride_z_r = r * stride_z_ex;
-                    double res_x = (x0[idx_ex - r]          + x0[idx_ex + r])          * stencil_coefs[3*r];
-                    double res_y = (x0[idx_ex - stride_y_r] + x0[idx_ex + stride_y_r]) * stencil_coefs[3*r+1];
-                    double res_z = (x0[idx_ex - stride_z_r] + x0[idx_ex + stride_z_r]) * stencil_coefs[3*r+2];
-                    res += res_x + res_y + res_z;
-                }
-                y[idx] = res + b * (v0[idx] * x0[idx_ex]) + beta*y[idx];
-            }
-        }
-    }    
+        case 4:
+            stencil_3axis_thread_radius4(
+                x0, radius, stride_y,  stride_y_ex, stride_z, stride_z_ex,
+                x_spos, x_epos, y_spos, y_epos, z_spos, z_epos, x_ex_spos, y_ex_spos, z_ex_spos,
+                stencil_coefs, coef_0, b, v0, y
+            );
+            return;
+            break;
+
+        case 6:
+            stencil_3axis_thread_radius6(
+                x0, radius, stride_y,  stride_y_ex, stride_z, stride_z_ex,
+                x_spos, x_epos, y_spos, y_epos, z_spos, z_epos, x_ex_spos, y_ex_spos, z_ex_spos,
+                stencil_coefs, coef_0, b, v0, y
+            );
+            return;
+            break;
+
+        case 8:
+            stencil_3axis_thread_radius8(
+                x0, radius, stride_y,  stride_y_ex, stride_z, stride_z_ex,
+                x_spos, x_epos, y_spos, y_epos, z_spos, z_epos, x_ex_spos, y_ex_spos, z_ex_spos,
+                stencil_coefs, coef_0, b, v0, y
+            );
+            return;
+            break;
+
+        default:
+            stencil_3axis_thread_variable_radius(
+                x0, radius, stride_y,  stride_y_ex, stride_z, stride_z_ex,
+                x_spos, x_epos, y_spos, y_epos, z_spos, z_epos, x_ex_spos, y_ex_spos, z_ex_spos,
+                stencil_coefs, coef_0, b, v0, y
+            );
+            return;
+            break;
+    }
 }
 
 


### PR DESCRIPTION
1. When the FD order = `12`, use a hard-coded version of the (orthogonal, gamma-point) stencil to improve its efficiency.