### PR TITLE
add eig_paral_orfac option; modify default EIG_SERIAL_MAXNS to 1500

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -6,11 +6,13 @@
 
 --------------
 Oct 09, 2022
-Name: Boqin Zhang
-Changes: (initialization.c)
+Name: Boqin Zhang, Qimen Xu
+Changes: (initialization.c, eigenSolver.c, eigenSolverKpt.c, readfiles.c, isddft.h)
 1. Fix a bug in counting d3 computation time in debug mode
 2. Check the availability of MD method in initialization.c
 3. Add the missed "-" in "z-direction"
+4. Add `eig_paral_orfac` option to control the reorthogonalization of parallel eigensolvers p?syevx and p?sygvx. The default is 0.0.
+5. Modify default `EIG_SERIAL_MAXNS` value to 1500.
 
 
 --------------

--- a/src/eigenSolver.c
+++ b/src/eigenSolver.c
@@ -1492,7 +1492,7 @@ void Solve_Generalized_EigenProblem(SPARC_OBJ *pSPARC, int k, int spn_i)
              * processes do not. i.e., where the data are concentrated.
              */
             //lwork += min(10*lwork,2000000); // TODO: for safety, to be optimized
-            if (fabs(orfac) > TEMP_TOL) lwork += max(N*N, min(10*lwork,2000000));
+            lwork += max(N*N, min(10*lwork,2000000));
             work = realloc(work, lwork * sizeof(double));
             
             liwork = iwork[0];
@@ -1500,7 +1500,7 @@ void Solve_Generalized_EigenProblem(SPARC_OBJ *pSPARC, int k, int spn_i)
             liwork = max(liwork, 6 * NNP);
             
             //liwork += min(20*liwork, 200000); // TODO: for safety, to be optimized
-            //liwork += max(N*N, min(20*liwork, 200000));
+            liwork += max(N*N, min(20*liwork, 200000));
             iwork = realloc(iwork, liwork * sizeof(int));
 
             /** ScaLAPACK might fail when the the matrix is distributed only on 

--- a/src/eigenSolverKpt.c
+++ b/src/eigenSolverKpt.c
@@ -1241,7 +1241,7 @@ void Solve_Generalized_EigenProblem_kpt(SPARC_OBJ *pSPARC, int kpt, int spn_i)
          * processes do not. i.e., where the data are concentrated.
          */
         //lwork += min(10*lwork,2000000); // TODO: for safety, to be optimized
-        if (fabs(orfac) > TEMP_TOL) lwork += max(N*N, min(10*lwork,2000000));
+        lwork += max(N*N, min(10*lwork,2000000));
 	    work = realloc(work, lwork * sizeof(double complex));
         
         
@@ -1256,7 +1256,7 @@ void Solve_Generalized_EigenProblem_kpt(SPARC_OBJ *pSPARC, int kpt, int spn_i)
         liwork = max(liwork, 6 * NNP);
 
         //liwork += min(20*liwork, 200000); // TODO: for safety, to be optimized
-        //liwork += max(N*N, min(20*liwork, 200000));
+        liwork += max(N*N, min(20*liwork, 200000));
 	    iwork = realloc(iwork, liwork * sizeof(int));
 
         /** ScaLAPACK might fail when the the matrix is distributed only on 

--- a/src/include/isddft.h
+++ b/src/include/isddft.h
@@ -482,7 +482,9 @@ typedef struct _SPARC_OBJ{
                         // for Nstates greater than this value, ScaLAPACK will be used instead, unless 
                         // useLAPACK is turned off.
     int eig_paral_blksz; // block size for distributing the subspace eigenproblem
-    
+    double eig_paral_orfac; // specifies which eigenvectors should be reorthogonalized when the "expert" parallel
+                            // eigensolver p?syevx or p?sygvx is used.
+
     /* tool variable*/
     MPI_Request req_veff_loc;     // when transmitting Veff_loc, we use nonblocking collectives, 
                                   // this is for checking if transmition is completed later
@@ -1126,6 +1128,10 @@ typedef struct _SPARC_INPUT_OBJ{
     /* Cell relaxation */
     double max_dilatation;
     double TOL_RELAX_CELL;
+
+    /* eigensolver */
+    double eig_paral_orfac; // specifies which eigenvectors should be reorthogonalized when the "expert" parallel
+                            // eigensolver p?syevx or p?sygvx is used.
 
     /* Method options */
     char MDMeth[32];

--- a/src/makefile
+++ b/src/makefile
@@ -13,7 +13,7 @@ USE_DP_SUBEIG = 0
 # Set USE_FFTW = 1 to use FFTW for fast Fourier transform in vdWDF. Don't open it together with USE_MKL
 USE_FFTW      = 0
 # Set DEBUG_MODE = 1 to run with debug mode and print debug output
-DEBUG_MODE    = 1
+DEBUG_MODE    = 0
 
 # Enable SIMD vectorization for complex stencil routines
 # CAUTION: for some compilers this results in wrong results! Use for intel/19.0.3 or later versions

--- a/src/readfiles.c
+++ b/src/readfiles.c
@@ -120,6 +120,9 @@ void read_input(SPARC_INPUT_OBJ *pSPARC_Input, SPARC_OBJ *pSPARC) {
         } else if (strcmpi(str,"EIG_PARAL_BLKSZ:") == 0) {
             fscanf(input_fp,"%d", &pSPARC_Input->eig_paral_blksz);
             fscanf(input_fp, "%*[^\n]\n");
+        } else if (strcmpi(str,"EIG_PARAL_ORFAC:") == 0) {
+            fscanf(input_fp,"%lf", &pSPARC_Input->eig_paral_orfac);
+            fscanf(input_fp, "%*[^\n]\n");
         } else if (strcmpi(str,"CELL:") == 0) {
             Flag_cell = 1;
             fscanf(input_fp,"%lf", &pSPARC_Input->range_x);


### PR DESCRIPTION
* Add `eig_paral_orfac` option to control the reorthogonalization of parallel eigensolvers p?syevx and p?sygvx. The default is 0.0.
* Modify default `EIG_SERIAL_MAXNS` value to 1500.