### PR TITLE
Update installation instructions from conda-forge

### DIFF
--- a/.conda/activate.sh
+++ b/.conda/activate.sh
@@ -1,1 +1,2 @@
 export SPARC_PSP_PATH="${CONDA_PREFIX}/share/sparc/psps"
+export SPARC_DOC_PATH="${CONDA_PREFIX}/doc/sparc"

--- a/.conda/build.sh
+++ b/.conda/build.sh
@@ -1,12 +1,23 @@
 #!/bin/bash
+# The build script is intended to be used on the root level
 echo Compiling sparc using ${CPU_COUNT} cores
+
 cd ./src
 make clean
 make -j ${CPU_COUNT} USE_MKL=0 USE_SCALAPACK=1
+
 # ls -al lib
 echo "Installing sparc into $PREFIX/bin"
 cp ../lib/sparc $PREFIX/bin
 echo "Moving sparc psp into $PREFIX/share/sparc/psps"
 mkdir -p $PREFIX/share/sparc/psps
 cp ../psps/* $PREFIX/share/sparc/psps/
+mkdir -p $PREFIX/doc/sparc
+cp -r ../doc/ $PREFIX/doc/sparc/
 echo "Finish compiling sparc!"
+
+# Copy activate and deactivate scripts
+cd ../.conda/
+cp activate.sh $PREFIX/etc/conda/activate.d/activate-sparc.sh
+cp deactivate.sh $PREFIX/etc/conda/deactivate.d/deactivate-sparc.sh
+echo "Finish setting up activate / deactivate scripts"

--- a/.conda/deactivate.sh
+++ b/.conda/deactivate.sh
@@ -1,1 +1,2 @@
 unset SPARC_PSP_PATH
+unset SPARC_DOC_PATH

--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -21,7 +21,7 @@ source:
 requirements:
   target:
     - linux-64
-    # - linux-aarch64
+    - linux-aarch64
   host:
     - compilers
     - openmpi

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,14 @@ sparc
 .vscode
 dev_tests/
 *~
+*#*#
+/conda/
+/doc/.LaTeX/**/*.out
+/doc/.LaTeX/**/*.aux
+/doc/.LaTeX/**/*.vrb
+/doc/.LaTeX/**/*.out
+/doc/.LaTeX/**/*.log
+/doc/.LaTeX/**/auto/
+/doc/.LaTeX/Manual.pdf*
+/doc/.LaTeX/**/*.synctex*
+/README.html

--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,13 @@
 -changes
 
 --------------
+Sep 06, 2023
+Name: Tian Tian
+Changes: (README.md, doc/)
+1. Add installation instruction for conda-forge
+2. Update the installation section in manual
+
+--------------
 Sep 05, 2023
 Name: Xin Jing
 Changes: (all files)

--- a/README.md
+++ b/README.md
@@ -75,6 +75,25 @@ There are several options to compile SPARC, depending on the available external 
 
 Once compilation is done, a binary named `sparc` will be created in the `lib/` directory.
 
+* Option 4: Install pre-compiled `sparc` binaries distributed by `conda-forge`
+
+Pre-compiled `sparc` package can be installed on x86_64 or aarch64 Linux platforms using `anaconda` or `miniconda`. 
+The binary is compiled with OpenBLAS and OpenMPI and flags `USE_MKL=0 USE_SCALAPACK=1 USE_FFTW=1`.
+
+  * Step 1 (optional): create a conda environment (e.g. `sparc-env`)
+    ```shell
+    conda create -n sparc-env
+    conda activate sparc-env
+    ```
+  * Step 2: install conda package `sparc-x`
+    ```shell
+    conda install -c conda-forge sparc-x
+    echo sparc binary is located at: $(which sparc)
+    echo .psp files installed at: $SPARC_PSP_PATH
+    echo SPARC doc files installed at: $SPARC_DOC_PATH
+    ```
+
+
 ### (3) Input files:
 The required input files to run a simulation with SPARC are (with shared names)  
 

--- a/doc/.LaTeX/Introduction.tex
+++ b/doc/.LaTeX/Introduction.tex
@@ -134,6 +134,35 @@ If you publish work using/regarding SPARC, please cite some of the following art
   \begin{frame}[allowframebreaks,fragile]{\textbf{Installation - lib}} \label{Installation:lib}
   Once compilation is done, a binary named \texttt{sparc} will be created in the \texttt{lib/} directory.
   \end{frame}
+
+  \begin{frame}[allowframebreaks,fragile]{\textbf{Installation - Option 4}} \label{Installation:4}
+  \begin{itemize}
+  \item Option 4: Install pre-compiled \texttt{sparc} binaries distributed by \texttt{conda-forge}
+
+    Pre-compiled \texttt{sparc} package can be installed on x86\_64 or
+    aarch64 Linux platforms with \texttt{anaconda} or
+    \texttt{miniconda} installed.  The binary is compiled with
+    OpenBLAS and OpenMPI using flags \texttt{USE\_MKL=0 USE\_SCALAPACK=1 USE\_FFTW=1}.
+    
+    \begin{itemize}
+   
+    \item  Step 1 (optional): create a conda environment (e.g. \texttt{sparc-env})
+\begin{verbatim}
+$ conda create -n sparc-env
+$ conda activate sparc-env
+\end{verbatim}
+      
+    \item Step 2: install conda package \texttt{sparc-x}
+\begin{verbatim}
+$ conda install -c conda-forge sparc-x
+$ echo sparc binary is located at: $(which sparc)
+$ echo .psp files installed at: $SPARC_PSP_PATH
+$ echo SPARC doc files installed at: $SPARC_DOC_PATH
+\end{verbatim}
+    \end{itemize}
+  \end{itemize}
+  
+  \end{frame}
   
   
   
@@ -157,7 +186,7 @@ If you publish work using/regarding SPARC, please cite some of the following art
   \end{verbatim} 
   As an example, one can run one of the tests located in `SPARC/tests/`. First go to `SPARC/tests/Example\_tests/` directory:
   \begin{verbatim}
-  $ $ cd tests/Example_tests/
+  $ cd tests/Example_tests/
   \end{verbatim} 
   There are a few input files available. Run a DC silicon system by
   \begin{verbatim}


### PR DESCRIPTION
Update README and doc for installation by conda-forge. The official feedstock for SPARC-X is https://github.com/conda-forge/sparc-x-feedstock