### PR TITLE
Firx bug in non-orthogonal cell and add warnings

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,15 @@
 -changes
 
 --------------
+Jan 27, 2023
+Name: Xin Jing
+Changes: (initialization.c)
+1. Fix a bug when the cell is a rotated cuboidal, use non-orthogonal calculation for that
+2. Add the warning for user to change the cell to get best performance
+3. Add warnings into .out file
+4. Remove SCF scriteria for QE and add warnings.
+
+--------------
 Oct 31, 2023
 Name: Boqin Zhang
 Changes: (md.c)

--- a/src/electrostatics.c
+++ b/src/electrostatics.c
@@ -586,7 +586,8 @@ void GetInfluencingAtoms(SPARC_OBJ *pSPARC) {
     double Lx, Ly, Lz, rbx, rby, rbz, x0, y0, z0, x0_i, y0_i, z0_i;
     double DMxs, DMxe, DMys, DMye, DMzs, DMze;
     int rb_xl, rb_xr, rb_yl, rb_yr, rb_zl, rb_zr;
-    int isRbOut[3] = {0,0,0}; // check rb-region of atom is out of the domain
+    int *isRbOut = pSPARC->isRbOut; // check rb-region of atom is out of the domain
+    isRbOut[0] = isRbOut[1] = isRbOut[2] = 0; 
     MPI_Comm grid_comm = pSPARC->dmcomm_phi;
     MPI_Comm_size(grid_comm, &nproc);
     MPI_Comm_rank(grid_comm, &rank);
@@ -757,9 +758,9 @@ void GetInfluencingAtoms(SPARC_OBJ *pSPARC) {
     } 
     if (pSPARC->BCx == 1 || pSPARC->BCy == 1 || pSPARC->BCz == 1) {        
         MPI_Allreduce(MPI_IN_PLACE, isRbOut, 3, MPI_INT, MPI_LAND, pSPARC->dmcomm_phi);
-        #ifdef DEBUG
-        if (!rank) printf("Is Rb region out? isRbOut = [%d, %d, %d]\n", isRbOut[0], isRbOut[1], isRbOut[2]);
-        #endif
+        if (isRbOut[0] || isRbOut[1] || isRbOut[2]) {
+            if (!rank) printf("WARNING: Atoms are too close to boundary for pseudocharge calculation.\n");
+        }
     }
 
 }

--- a/src/finalization.c
+++ b/src/finalization.c
@@ -220,12 +220,6 @@ void Free_basic(SPARC_OBJ *pSPARC) {
         if (pSPARC->MixingVariable == 0 && pSPARC->spin_typ) {
             free(pSPARC->electronDens_in);
         }
-
-        // for using QE scf error definition
-        if (pSPARC->scf_err_type == 1) {
-            free(pSPARC->rho_dmcomm_phi_in);
-            free(pSPARC->phi_dmcomm_phi_in);
-        }
         
         free(pSPARC->mixing_hist_Pfk);
     }

--- a/src/highT/sqParallelization.c
+++ b/src/highT/sqParallelization.c
@@ -337,14 +337,6 @@ void Setup_Comms_SQ(SPARC_OBJ *pSPARC) {
             assert(pSPARC->Veff_loc_dmcomm_phi_in != NULL);
         }
 
-        // The following rho_in and phi_in are only used for evaluating QE scf errors
-        if (pSPARC->scf_err_type == 1) {
-            pSPARC->rho_dmcomm_phi_in = (double *)malloc(DMnd * sizeof(double));
-            assert(pSPARC->rho_dmcomm_phi_in != NULL);
-            pSPARC->phi_dmcomm_phi_in = (double *)malloc(DMnd * sizeof(double));
-            assert(pSPARC->phi_dmcomm_phi_in != NULL);
-        }
-
         // initialize electrostatic potential as random guess vector
         if (pSPARC->FixRandSeed == 1) {
             SeededRandVec(pSPARC->elecstPotential, pSPARC->DMVertices, gridsizes, -1.0, 1.0, 0);

--- a/src/include/initialization.h
+++ b/src/include/initialization.h
@@ -94,11 +94,6 @@ void Calculate_SplineDerivRadFun(SPARC_OBJ *pSPARC);
 
 void Cart2nonCart_transformMat(SPARC_OBJ *pSPARC);
 
-/**
- * @brief   Write the initialized parameters into the output file.
- *
- * @param pSPARC    The pointer that points to SPARC_OBJ type structure.
- */
  
 /*
  * @brief   function to convert non cartesian to cartesian coordinates
@@ -134,6 +129,8 @@ void CalculateDistance(SPARC_OBJ *pSPARC, double x, double y, double z, double x
  */
 void write_output_init(SPARC_OBJ *pSPARC);
 
+
+void print_orthogonal_warning(SPARC_OBJ *pSPARC, FILE *output_fp);
 
 /**
  * @brief   Calculate k-points and the associated weights.

--- a/src/include/isddft.h
+++ b/src/include/isddft.h
@@ -222,6 +222,7 @@ typedef struct _SPARC_OBJ{
     int npNdx_kptcomm;  // number of processes in x-dir for creating Cartesian topology in kptcomm 
     int npNdy_kptcomm;  // number of processes in y-dir for creating Cartesian topology in kptcomm 
     int npNdz_kptcomm;  // number of processes in z-dir for creating Cartesian topology in kptcomm
+    int useDefaultParalFlag; // Flag for using default parallelization
     int FixRandSeed;    // flag to fix the random number seeds so that all random numbers generated in parallel 
                         // under MPI are the same as those generated in sequential execution
                         
@@ -346,6 +347,7 @@ typedef struct _SPARC_OBJ{
     int Nd_d_dmcomm;          // total number of grids of distributed domain in each dmcomm process (LOCAL)
     
     ATOM_INFLUENCE_OBJ *Atom_Influence_local; // atom info. for atoms that have local influence on the distributed domain (LOCAL)
+    int isRbOut[3];           // flag for if Rb region is outside domain for Dirichlet BC
     
     /* nonlocal */
     ATOM_NLOC_INFLUENCE_OBJ *Atom_Influence_nloc; // atom info. for atoms that have nonlocal influence on the distributed domain (LOCAL)
@@ -447,12 +449,7 @@ typedef struct _SPARC_OBJ{
     double *mixing_hist_Xk;      // residual matrix of Veff_loc, for mixing (LOCAL)
     double *mixing_hist_Fk;      // residual matrix of the residual of Veff_loc (LOCAL)
     double *mixing_hist_Pfk;     // the preconditioned residual distributed in phi-domain (LOCAL)
-
-    int    scf_err_type;        // scf error definition type
-    double t_qe_extra;          // // this is the extra unnecessary time we spent in order to evaluate QE scf error
-    // these two arrays are used only for evaluating QE scf error
-    double *rho_dmcomm_phi_in;  // input electron density distributed in phi-domain (LOCAL)
-    double *phi_dmcomm_phi_in;  // input electrostatic potential distributed in phi-domain (LOCAL)
+    
     double *psdChrgDens;          // pseudocharge density, "b" (LOCAL)
     double *psdChrgDens_ref;      // reference pseudocharge density, "b_ref" (LOCAL)
     double *Vc;                   // difference between reference pseudopotential V_ref and pseudopotential V, Vc = V_ref - V (LOCAL)
@@ -1058,7 +1055,6 @@ typedef struct _SPARC_INPUT_OBJ{
                         // under MPI are the same as those generated in sequential execution
                         // 0 - off (default), 1 - on
     int accuracy_level; // accuracy level, 1 - 'low', 2 - 'medium', 3 - 'high', 4 - 'extreme'
-    int scf_err_type;   // scf error definition type
     int MAXIT_SCF;      // max number of SCF iterations
     int MINIT_SCF;      // min number of SCF iterations
     int MAXIT_POISSON;  // max number of iterations for Poisson solver

--- a/src/md.c
+++ b/src/md.c
@@ -1225,7 +1225,7 @@ void reinitialize_mesh_NPT(SPARC_OBJ *pSPARC)
         pSPARC->ChebDegree = Mesh2ChebDegree(h_eff);
 #ifdef DEBUG
         if (!rank && h_eff < 0.1) {
-            printf("#WARNING: for mesh less than 0.1, the default Chebyshev polynomial degree might not be enought!\n");
+            printf("WARNING: for mesh less than 0.1, the default Chebyshev polynomial degree might not be enought!\n");
         }
         if (!rank) printf("h_eff = %.2f, npl = %d\n", h_eff,pSPARC->ChebDegree);
 #endif

--- a/src/parallelization.c
+++ b/src/parallelization.c
@@ -80,6 +80,10 @@ void Setup_Comms(SPARC_OBJ *pSPARC) {
         pSPARC->npNdx = dims[0];
         pSPARC->npNdy = dims[1];
         pSPARC->npNdz = dims[2];
+        pSPARC->useDefaultParalFlag = 1;
+    } else {
+        if (!rank) printf("WARNING: Default parallelization not used. This could result in degradation of performance.\n");
+        pSPARC->useDefaultParalFlag = 0;
     }
 
     //------------------------------------------------//
@@ -1103,14 +1107,6 @@ void Setup_Comms(SPARC_OBJ *pSPARC) {
         if (pSPARC->MixingVariable == 0 && pSPARC->spin_typ) {
             pSPARC->electronDens_in = (double *)malloc(DMnd * pSPARC->Nspdentd * sizeof(double));
             assert(pSPARC->electronDens_in != NULL);
-        }
-
-        // The following rho_in and phi_in are only used for evaluating QE scf errors
-        if (pSPARC->scf_err_type == 1) {
-            pSPARC->rho_dmcomm_phi_in = (double *)malloc(DMnd * sizeof(double));
-            assert(pSPARC->rho_dmcomm_phi_in != NULL);
-            pSPARC->phi_dmcomm_phi_in = (double *)malloc(DMnd * sizeof(double));
-            assert(pSPARC->phi_dmcomm_phi_in != NULL);
         }
 
         // initialize electrostatic potential as random guess vector

--- a/src/readfiles.c
+++ b/src/readfiles.c
@@ -418,15 +418,9 @@ void read_input(SPARC_INPUT_OBJ *pSPARC_Input, SPARC_OBJ *pSPARC) {
             fscanf(input_fp, "%*[^\n]\n");
         } else if (strcmpi(str,"TOL_SCF:") == 0) { 
             fscanf(input_fp,"%lf",&pSPARC_Input->TOL_SCF);
-            pSPARC_Input->scf_err_type = 0; // can remove since default is 0
             snprintf(str, L_STRING, "undefined");    // initialize str
             fscanf(input_fp, "%*[^\n]\n");
-        } /*else if (strcmpi(str,"TOL_SCF_QE:") == 0) { 
-            fscanf(input_fp,"%lf",&pSPARC_Input->TOL_SCF);
-            pSPARC_Input->scf_err_type = 1;
-            snprintf(str, L_STRING, "undefined");    // initialize str
-            fscanf(input_fp, "%*[^\n]\n");
-        } */else if (strcmpi(str,"TOL_POISSON:") == 0) {
+        } else if (strcmpi(str,"TOL_POISSON:") == 0) {
             fscanf(input_fp,"%lf",&pSPARC_Input->TOL_POISSON);
             fscanf(input_fp, "%*[^\n]\n");
         } else if (strcmpi(str,"TOL_RELAX:") == 0) {

--- a/src/relax.c
+++ b/src/relax.c
@@ -1236,7 +1236,7 @@ void reinitialize_cell_mesh(SPARC_OBJ *pSPARC, double vol)
             pSPARC->ChebDegree = Mesh2ChebDegree(h_eff);
     #ifdef DEBUG
             if (!rank && h_eff < 0.1) {
-                printf("#WARNING: for mesh less than 0.1, the default Chebyshev polynomial degree might not be enought!\n");
+                printf("WARNING: for mesh less than 0.1, the default Chebyshev polynomial degree might not be enought!\n");
             }
             if (!rank) printf("h_eff = %.2f, npl = %d\n", h_eff,pSPARC->ChebDegree);
     #endif


### PR DESCRIPTION
1. Fix a bug when the cell is a rotated cuboidal, use non-orthogonal calculation for that
2. Add the warning for user to change the cell to get best performance
3. Add warnings into .out file
4. Remove SCF scriteria for QE and add warnings.