### PR TITLE
Fix buildchain issue with openmpi

### DIFF
--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -24,15 +24,15 @@ requirements:
     - linux-aarch64
   host:
     - compilers
-    - openmpi
+    - openmpi=4
     - openblas
     - scalapack
-    - fftw
+    - fftw=4.*=mpi_openmpi_*
   run:
-    - openmpi
+    - openmpi=4
     - openblas
     - scalapack
-    - fftw
+    - fftw=4.*=mpi_openmpi_*
 
 about:
   home: https://www.sparc-x.com

--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -27,12 +27,12 @@ requirements:
     - openmpi 4.*
     - openblas
     - scalapack
-    - fftw 4.* mpi_openmpi_*
+    - fftw * mpi_openmpi_*
   run:
     - openmpi 4.*
     - openblas
     - scalapack
-    - fftw 4.* mpi_openmpi_*
+    - fftw * mpi_openmpi_*
 
 about:
   home: https://www.sparc-x.com

--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -24,15 +24,15 @@ requirements:
     - linux-aarch64
   host:
     - compilers
-    - openmpi=4
+    - openmpi 4.*
     - openblas
     - scalapack
-    - fftw=4.*=mpi_openmpi_*
+    - fftw 4.* mpi_openmpi_*
   run:
-    - openmpi=4
+    - openmpi 4.*
     - openblas
     - scalapack
-    - fftw=4.*=mpi_openmpi_*
+    - fftw 4.* mpi_openmpi_*
 
 about:
   home: https://www.sparc-x.com

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -40,6 +40,9 @@ jobs:
     - name: Install local build
       run: |
         mamba install --use-local sparc
+        which sparc
+        ldd $(which sparc)
+        ldd $(which mpirun)
     - name: Test simple sparc run
       run: |
         cd tests/Cu_FCC/standard/


### PR DESCRIPTION
A recent change in conda-forge's openmpi (v5.0.5) seems to be having issues, pinning all CI builds using openmpi 4.x