### PR TITLE
Fix issue with implicit function declaration error from newer gcc toolchains in CI

### DIFF
--- a/.conda/activate.sh
+++ b/.conda/activate.sh
@@ -1,2 +1,2 @@
 export SPARC_PSP_PATH="${CONDA_PREFIX}/share/sparc/psps"
-export SPARC_DOC_PATH="${CONDA_PREFIX}/doc/sparc"
+export SPARC_DOC_PATH="${CONDA_PREFIX}/doc/sparc/doc/.LaTeX"

--- a/.conda/build.sh
+++ b/.conda/build.sh
@@ -13,7 +13,8 @@ echo "Moving sparc psp into $PREFIX/share/sparc/psps"
 mkdir -p $PREFIX/share/sparc/psps
 cp ../psps/* $PREFIX/share/sparc/psps/
 mkdir -p $PREFIX/doc/sparc
-cp -r ../doc/ $PREFIX/doc/sparc/
+cp -R ../doc/* $PREFIX/doc/sparc/
+cp -R ../doc/.[!.]* $PREFIX/doc/sparc/
 echo "Finish compiling sparc!"
 
 # Copy activate and deactivate scripts

--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,12 @@
 -Name
 -changes
 --------------
+September 03, 2025
+Name: Tian Tian
+Changes: src/initialization.c, src/socket/driver.c, src/socket/driver.h
+1. Add references to functions to avoid implicit function declarationerror in newer gcc compilation toolchains
+
+--------------
 July 17, 2025
 Name: Sayan Bhowmik
 Changes: src/include/isddft.h, src/initialization.c, src/readfiles.c, src/relax.c,

--- a/src/initialization.c
+++ b/src/initialization.c
@@ -3722,7 +3722,7 @@ void write_output_init(SPARC_OBJ *pSPARC) {
     }
 
     fprintf(output_fp,"***************************************************************************\n");
-    fprintf(output_fp,"*                       SPARC (version June 17, 2025)                      *\n");
+    fprintf(output_fp,"*                       SPARC (version September 03, 2025)                      *\n");
     fprintf(output_fp,"*   Copyright (c) 2020 Material Physics & Mechanics Group, Georgia Tech   *\n");
     fprintf(output_fp,"*           Distributed under GNU General Public License 3 (GPL)          *\n");
     fprintf(output_fp,"*                   Start time: %s                  *\n",c_time_str);

--- a/src/socket/driver.c
+++ b/src/socket/driver.c
@@ -22,7 +22,7 @@
 #include "initialization.h"
 /* #include "orbitalElecDensInit.h" */
 #include "electronicGroundState.h"
-#include "relax.h"
+/* #include "relax.h" */
 #include "eigenSolver.h" // Mesh2Cheb
 #include "electrostatics.h" // Calculate_PseudochargeCutoff
 

--- a/src/socket/driver.c
+++ b/src/socket/driver.c
@@ -1017,7 +1017,7 @@ void print_socket_error_info(SPARC_OBJ *pSPARC)
 
   FILE *output_fp = fopen(pSPARC->OutFilename,"w");
   if (output_fp == NULL) {
-    printf(stderr, "\nCannot open file \"%s\"\n",pSPARC->OutFilename);
+    fprintf(stderr, "\nCannot open file \"%s\"\n",pSPARC->OutFilename);
     exit(EXIT_FAILURE);
   }
 

--- a/src/socket/driver.c
+++ b/src/socket/driver.c
@@ -23,9 +23,15 @@
 /* #include "orbitalElecDensInit.h" */
 #include "electronicGroundState.h"
 #include "relax.h"
+#include "eigenSolver.h" // Mesh2Cheb
+#include "electrostatics.h" // Calculate_PseudochargeCutoff
+
 /* #include "md.h" */
 
 /* Tools to be used in socket interface. Don't need #ifdef switches */
+int write_message_to_socket(SPARC_OBJ *pSPARC, char *message);
+void map_atom_coord(SPARC_OBJ *pSPARC);
+
 
 int split_socket_name(const char *str, char *host, int *port, int *inet)
 {

--- a/src/socket/driver.c
+++ b/src/socket/driver.c
@@ -22,7 +22,7 @@
 #include "initialization.h"
 /* #include "orbitalElecDensInit.h" */
 #include "electronicGroundState.h"
-/* #include "relax.h" */
+#include "relax.h"
 #include "eigenSolver.h" // Mesh2Cheb
 #include "electrostatics.h" // Calculate_PseudochargeCutoff
 

--- a/src/socket/driver.c
+++ b/src/socket/driver.c
@@ -20,13 +20,11 @@
 #include "libunixsocket.h"
 
 #include "initialization.h"
-/* #include "orbitalElecDensInit.h" */
 #include "electronicGroundState.h"
 #include "relax.h"
 #include "eigenSolver.h" // Mesh2Cheb
 #include "electrostatics.h" // Calculate_PseudochargeCutoff
 
-/* #include "md.h" */
 
 /* Tools to be used in socket interface. Don't need #ifdef switches */
 int write_message_to_socket(SPARC_OBJ *pSPARC, char *message);

--- a/src/socket/driver.h
+++ b/src/socket/driver.h
@@ -47,6 +47,11 @@ int close_Socket(SPARC_OBJ *pSPARC);
  **/
 void main_Socket(SPARC_OBJ *pSPARC);
 
+/**
+ * @brief   Print static file information when socket is present
+ **/
+void socket_static_print_atom_pos(SPARC_OBJ *pSPARC)
+
 // IPI constants
 
 #define IPI_HEADERLEN 12

--- a/src/socket/driver.h
+++ b/src/socket/driver.h
@@ -50,7 +50,7 @@ void main_Socket(SPARC_OBJ *pSPARC);
 /**
  * @brief   Print static file information when socket is present
  **/
-void socket_static_print_atom_pos(SPARC_OBJ *pSPARC)
+void socket_static_print_atom_pos(SPARC_OBJ *pSPARC);
 
 // IPI constants
 


### PR DESCRIPTION
In recent changes of compiler toolchains from conda-forge, the implicit function declaration escalated from warning to error, preventing the code passing CI pipelines. This PR provides a fix